### PR TITLE
Fix device info method typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ from aduro.session import AduroSession
 aduro_session = AduroSession(session_id)
 stove_ids = await aduro_session.async_get_stove_ids()
 
-device_info = await aduro_session.aync_get_device_info(stove_ids[0])
+device_info = await aduro_session.async_get_device_info(stove_ids[0])
 
 ```
 

--- a/aduro/session.py
+++ b/aduro/session.py
@@ -120,8 +120,8 @@ class AduroSession:  # pylint: disable=too-few-public-methods
         data = SearchResponse(**raw) if raw else None
         return data.id if data else None
 
-    async def aync_get_device_info(self, device_id: str) -> Device | None:
-        """Get devices.
+    async def async_get_device_info(self, device_id: str) -> Device | None:
+        """Get device information.
 
         :return: Device
         :rtype: Device

--- a/aduro/session.py
+++ b/aduro/session.py
@@ -1,4 +1,5 @@
 """Aduro session"""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_session_integration.py
+++ b/tests/test_session_integration.py
@@ -44,7 +44,7 @@ async def test_get_stove_id_with_unknown_session_id_raises_aduro_response_error(
 async def test_successful_get_device_info(session_id):
     """Test getting the device info."""
     aduro_session = AduroSession(session_id)
-    device_info = await aduro_session.aync_get_device_info(
+    device_info = await aduro_session.async_get_device_info(
         "373371fe-9735-4069-25d6-44a93531a982",
     )
     assert device_info is not None
@@ -55,7 +55,7 @@ async def test_get_device_info_with_unknown_session_id_raises_aduro_response_err
     """Test getting the device info."""
     aduro_session = AduroSession("session_id")
     with pytest.raises(AduroResponseError):
-        await aduro_session.aync_get_device_info(
+        await aduro_session.async_get_device_info(
             "373371fe-9735-4069-25d6-44a93531a982",
         )
 
@@ -67,14 +67,14 @@ async def test_get_device_info_with_unknown_stove_id_raises_aduro_response_error
     """Test getting the device info."""
     aduro_session = AduroSession(session_id)
     with pytest.raises(AduroResponseError):
-        await aduro_session.aync_get_device_info("bongo")
+        await aduro_session.async_get_device_info("bongo")
 
 
 @pytest.mark.asyncio
 async def test_get_device_entities(session_id):
     """Test getting device entities"""
     aduro_session = AduroSession(session_id)
-    device = await aduro_session.aync_get_device_info(
+    device = await aduro_session.async_get_device_info(
         "373371fe-9735-4069-25d6-44a93531a982",
     )
     entities = await aduro_session.async_get_device_entities(device.value)
@@ -88,7 +88,7 @@ async def test_get_device_entities(session_id):
 async def test_entity_state(session_id):
     """Test entity status"""
     aduro_session = AduroSession(session_id)
-    device = await aduro_session.aync_get_device_info(
+    device = await aduro_session.async_get_device_info(
         "373371fe-9735-4069-25d6-44a93531a982",
     )
     entities = await aduro_session.async_get_device_entities(device.value)

--- a/tests/test_session_integration.py
+++ b/tests/test_session_integration.py
@@ -1,4 +1,5 @@
 """Integration testing for Aduro API."""
+
 import os
 from datetime import datetime
 


### PR DESCRIPTION
## Summary
- rename `aync_get_device_info` to `async_get_device_info`
- update docs and tests for the corrected name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6883d0903ed8832cb0d66d127db925c3